### PR TITLE
Fix timezone date selection issue

### DIFF
--- a/app/js/datepicker.jsx
+++ b/app/js/datepicker.jsx
@@ -252,18 +252,21 @@ class DatePicker extends React.Component {
         }
     }
 
-
     handleStartDateSet() {
         const dateString = this.validateDateString(this.state.startDateInputValue);
         const startDate = moment(dateString);
         const minDate = this.getMinDateForType("startDate");
         const maxDate = this.getMaxDateForType("startDate");
 
+        if (!this.props.enableTime) {
+            // round to make sure it's simply the same date;
+            startDate.hour(0).minute(0).second(0).millisecond(0);
+        }
         // If it's a valid date string and the date is within range, set the start date to be the input value
         if (dateString && startDate.isSameOrAfter(minDate) && startDate.isSameOrBefore(maxDate)) {
             this.setState({
                 startDate: startDate,
-                startDateInputValue: moment(dateString).format(this.state.format)
+                startDateInputValue: startDate.format(this.state.format)
             }, () => {
                 this.handleOnChange();
                 if (this.dateView.current) {
@@ -274,10 +277,8 @@ class DatePicker extends React.Component {
             // If invalid date, set input value back to the last validated date
             this.setState({
                 startDateInputValue: this.state.startDate.format(this.state.format)
-            })
+            });
         }
-
-        this.forceUpdate();
     }
 
     handleEndDateSet() {
@@ -286,22 +287,26 @@ class DatePicker extends React.Component {
         const minDate = this.getMinDateForType("endDate");
         const maxDate = this.getMaxDateForType("endDate");
 
+        if (!this.props.enableTime) {
+            // round to make sure it's simply the same date;
+            endDate.hour(0).minute(0).second(0).millisecond(0);
+        }
         // If it's a valid date string and the date is within range, set the start date to be the input value
         if (dateString && endDate.isSameOrAfter(minDate) && endDate.isSameOrBefore(maxDate)) {
             this.setState({
                 endDate: endDate,
-                endDateInputValue: moment(dateString).format(this.state.format)
+                endDateInputValue: endDate.format(this.state.format)
             }, () => {
                 this.handleOnChange();
                 if (this.dateView.current) {
                     this.dateView.current.reset();
                 }
-            })
+            });
         } else {
             // If invalid date, set input value back to the last validated date
             this.setState({
                 endDateInputValue: this.state.endDate.format(this.state.format)
-            })
+            });
         }
     }
 

--- a/app/js/datepicker.jsx
+++ b/app/js/datepicker.jsx
@@ -1,9 +1,9 @@
-import React from 'react';
-import ReactDOM from 'react-dom';
-import PropTypes from 'prop-types';
-import DateView from './date-view';
-import moment from 'moment';
-import chrono from 'chrono-node';
+import React from "react";
+import ReactDOM from "react-dom";
+import PropTypes from "prop-types";
+import DateView from "./date-view";
+import moment from "moment";
+import chrono from "chrono-node";
 
 const DEFAULT_DATE_FORMAT = "MM/DD/YYYY";
 const DEFAULT_DATE_TIME_FORMAT = "MM/DD/YYYY h:mm a";
@@ -42,7 +42,7 @@ class DatePicker extends React.Component {
         let startDate = this.props.defaultDate;
 
 
-        if(!startDate) {
+        if (!startDate) {
             startDate = moment();
         }
 
@@ -79,15 +79,15 @@ class DatePicker extends React.Component {
     }
 
     componentDidMount() {
-        if(this.props.isRange) {
+        if (this.props.isRange) {
             this.props.onChange({
                 startDate: this.state.startDate.toDate(),
                 endDate: this.state.endDate.toDate()
-            })
+            });
         } else {
             this.props.onChange({
                 date: this.state.startDate.toDate()
-            })
+            });
         }
     }
 
@@ -97,7 +97,7 @@ class DatePicker extends React.Component {
             let endDate = newProps.defaultEndDate;
             let startDate = newProps.defaultDate;
 
-            if(!startDate) {
+            if (!startDate) {
                 startDate = moment();
             }
 
@@ -116,9 +116,7 @@ class DatePicker extends React.Component {
 
 
     toggleGlobalClickBinding() {
-        var wrapper = ReactDOM.findDOMNode(this);
-
-        if(this.state.datepickerVisible) {
+        if (this.state.datepickerVisible) {
             this.naturalBinders.bind();
         } else {
             this.naturalBinders.unbind();
@@ -128,10 +126,10 @@ class DatePicker extends React.Component {
     /**** helpers ****/
 
     getMinDateForType(type) {
-        if(type === "startDate") {
+        if (type === "startDate") {
             return this.props.minDate;
-        } else if(type === "endDate") {
-            if(this.state.startDate.isAfter(this.props.minDate)) {
+        } else if (type === "endDate") {
+            if (this.state.startDate.isAfter(this.props.minDate)) {
                 return this.state.startDate;
             } else {
                 return this.props.minDate;
@@ -142,10 +140,10 @@ class DatePicker extends React.Component {
     }
 
     getMaxDateForType(type) {
-        if(type === "endDate") {
+        if (type === "endDate") {
             return this.props.maxDate;
-        } else if(type === "startDate") {
-            if(this.state.endDate.isBefore(this.props.maxDate) && this.props.isRange) {
+        } else if (type === "startDate") {
+            if (this.state.endDate.isBefore(this.props.maxDate) && this.props.isRange) {
                 return this.state.endDate;
             } else {
                 return this.props.maxDate;
@@ -163,7 +161,9 @@ class DatePicker extends React.Component {
     /**** handlers ****/
 
     toggleDatepicker(type, e) {
-        if(e) e.stopPropagation();
+        if (e) {
+            e.stopPropagation();
+        }
 
         this.setState({
             datepickerVisible: type
@@ -171,7 +171,9 @@ class DatePicker extends React.Component {
     }
 
     openDatepicker(type, e) {
-        if(e) e.stopPropagation();
+        if (e) {
+            e.stopPropagation();
+        }
 
         this.setState({
             datepickerVisible: type
@@ -180,7 +182,9 @@ class DatePicker extends React.Component {
 
 
     closeDatepicker(type, e) {
-        if(e) e.stopPropagation();
+        if (e) {
+            e.stopPropagation();
+        }
 
         if (type === "startDate") {
             this.handleStartDateSet();
@@ -196,16 +200,16 @@ class DatePicker extends React.Component {
 
         // round to make sure it's simply the same date;
         mutableDate.hour(0).minute(0).second(0).millisecond(0);
-        if(mutableDate.isBefore(this.props.minDate) || mutableDate.isAfter(this.props.maxDate)) {
+        if (mutableDate.isBefore(this.props.minDate) || mutableDate.isAfter(this.props.maxDate)) {
             return false;
         }
 
-        if(type === "endDate") {
-            if(date.isSameOrBefore(this.state.startDate)) {
+        if (type === "endDate") {
+            if (date.isSameOrBefore(this.state.startDate)) {
                 return false;
             }
-        } else if(type === "startDate") {
-            if(date.isSameOrAfter(this.state.endDate) && this.props.isRange) {
+        } else if (type === "startDate") {
+            if (date.isSameOrAfter(this.state.endDate) && this.props.isRange) {
                 return false;
             }
         }
@@ -213,8 +217,8 @@ class DatePicker extends React.Component {
         var newState = {};
         newState.datepickerVisible = null;
 
-        if(options && typeof options.collapse === "boolean") {
-            if(!options.collapse) {
+        if (options && typeof options.collapse === "boolean") {
+            if (!options.collapse) {
                 newState.datepickerVisible = type;
             }
         }
@@ -251,6 +255,7 @@ class DatePicker extends React.Component {
             this.handleEndDateSet();
         }
     }
+
 
     handleStartDateSet() {
         const dateString = this.validateDateString(this.state.startDateInputValue);
@@ -315,11 +320,11 @@ class DatePicker extends React.Component {
             this.props.onChange({
                 startDate: this.state.startDate.toDate(),
                 endDate: this.state.endDate.toDate()
-            })
+            });
         } else {
             this.props.onChange({
                 date: this.state.startDate.toDate()
-            })
+            });
         }
 
         this.toggleGlobalClickBinding();
@@ -329,7 +334,7 @@ class DatePicker extends React.Component {
     /**** render methods ****/
 
     renderDatepicker(type) {
-        if(this.state.datepickerVisible === type) {
+        if (this.state.datepickerVisible === type) {
             return <DateView
                 ref={this.dateView}
                 enableTime={this.props.enableTime}
@@ -343,33 +348,33 @@ class DatePicker extends React.Component {
     render() {
         var endDateDatepicker = null, divider = null, styles = {};
 
-        if(this.props.inputWidth) {
+        if (this.props.inputWidth) {
             styles.width = this.props.inputWidth + "px";
-        } else if(this.props.enableTime) {
+        } else if (this.props.enableTime) {
             styles.width = "120px";
         } else {
             styles.width = "70px";
         }
 
-        if(this.props.isRange) {
+        if (this.props.isRange) {
             const endDateValue = this.props.inputEditable ? this.state.endDateInputValue : this.state.endDate.format(this.state.format);
             endDateDatepicker = (
                 <div className="datepicker-container">
                     <i className="fa fa-calendar"></i>
-                    <input  style={styles}
-                            className="datepicker-input"
-                            readOnly={!this.props.inputEditable}
-                            value={endDateValue}
-                            type="text"
+                    <input style={styles}
+                        className="datepicker-input"
+                        readOnly={!this.props.inputEditable}
+                        value={endDateValue}
+                        type="text"
 
-                            onChange={this.handleEndDateInputChange.bind(this)}
-                            onBlur={this.closeDatepicker.bind(this, "endDate")}
-                            onFocus={this.openDatepicker.bind(this, "endDate")}
-                            onKeyPress={this.handleEndDateKeyPress.bind(this)} />
+                        onChange={this.handleEndDateInputChange.bind(this)}
+                        onBlur={this.closeDatepicker.bind(this, "endDate")}
+                        onFocus={this.openDatepicker.bind(this, "endDate")}
+                        onKeyPress={this.handleEndDateKeyPress.bind(this)} />
                     {this.renderDatepicker("endDate")}
                 </div>
             );
-            divider =  <span className="datepicker-divider">-</span>;
+            divider = <span className="datepicker-divider">-</span>;
         }
         const startDateValue = this.props.inputEditable ? this.state.startDateInputValue : this.state.startDate.format(this.state.format);
 
@@ -377,21 +382,21 @@ class DatePicker extends React.Component {
             <div onClick={stopBubble} className="datepicker-wrapper">
                 <div className="datepicker-container">
                     <i className="fa fa-calendar"></i>
-                    <input  style={styles}
-                            className="datepicker-input"
-                            readOnly={!this.props.inputEditable}
-                            value={startDateValue}
-                            type="text"
-                            onBlur={this.closeDatepicker.bind(this, "startDate")}
-                            onFocus={this.openDatepicker.bind(this, "startDate")}
-                            onChange={this.handleStartDateInputChange.bind(this)}
-                            onKeyPress={this.handleStartDateKeyPress.bind(this)} />
+                    <input style={styles}
+                        className="datepicker-input"
+                        readOnly={!this.props.inputEditable}
+                        value={startDateValue}
+                        type="text"
+                        onBlur={this.closeDatepicker.bind(this, "startDate")}
+                        onFocus={this.openDatepicker.bind(this, "startDate")}
+                        onChange={this.handleStartDateInputChange.bind(this)}
+                        onKeyPress={this.handleStartDateKeyPress.bind(this)} />
                     {this.renderDatepicker("startDate")}
                 </div>
                 {divider}
                 {endDateDatepicker}
             </div>
-        )
+        );
         return content;
     }
 }
@@ -410,11 +415,11 @@ function getBinders(callback) {
         unbind: function() {
             document.removeEventListener("click", callback, false);
         }
-    }
+    };
 }
 
 function noop(data) {
-   console.log("changing", data);
+    console.log("changing", data);
 }
 
 

--- a/build/js/datepicker.js
+++ b/build/js/datepicker.js
@@ -1,28 +1,28 @@
-'use strict';
+"use strict";
 
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
-var _react = require('react');
+var _react = require("react");
 
 var _react2 = _interopRequireDefault(_react);
 
-var _reactDom = require('react-dom');
+var _reactDom = require("react-dom");
 
 var _reactDom2 = _interopRequireDefault(_reactDom);
 
-var _propTypes = require('prop-types');
+var _propTypes = require("prop-types");
 
 var _propTypes2 = _interopRequireDefault(_propTypes);
 
-var _dateView = require('./date-view');
+var _dateView = require("./date-view");
 
 var _dateView2 = _interopRequireDefault(_dateView);
 
-var _moment = require('moment');
+var _moment = require("moment");
 
 var _moment2 = _interopRequireDefault(_moment);
 
-var _chronoNode = require('chrono-node');
+var _chronoNode = require("chrono-node");
 
 var _chronoNode2 = _interopRequireDefault(_chronoNode);
 
@@ -87,7 +87,7 @@ var DatePicker = function (_React$Component) {
     }
 
     _createClass(DatePicker, [{
-        key: 'componentDidMount',
+        key: "componentDidMount",
         value: function componentDidMount() {
             if (this.props.isRange) {
                 this.props.onChange({
@@ -101,7 +101,7 @@ var DatePicker = function (_React$Component) {
             }
         }
     }, {
-        key: 'componentWillReceiveProps',
+        key: "componentWillReceiveProps",
         value: function componentWillReceiveProps(newProps) {
             if (newProps.defaultEndDate !== this.props.defaultEndDate || newProps.defaultDate !== this.props.defaultDate) {
                 var endDate = newProps.defaultEndDate;
@@ -124,10 +124,8 @@ var DatePicker = function (_React$Component) {
             }
         }
     }, {
-        key: 'toggleGlobalClickBinding',
+        key: "toggleGlobalClickBinding",
         value: function toggleGlobalClickBinding() {
-            var wrapper = _reactDom2.default.findDOMNode(this);
-
             if (this.state.datepickerVisible) {
                 this.naturalBinders.bind();
             } else {
@@ -138,7 +136,7 @@ var DatePicker = function (_React$Component) {
         /**** helpers ****/
 
     }, {
-        key: 'getMinDateForType',
+        key: "getMinDateForType",
         value: function getMinDateForType(type) {
             if (type === "startDate") {
                 return this.props.minDate;
@@ -153,7 +151,7 @@ var DatePicker = function (_React$Component) {
             }
         }
     }, {
-        key: 'getMaxDateForType',
+        key: "getMaxDateForType",
         value: function getMaxDateForType(type) {
             if (type === "endDate") {
                 return this.props.maxDate;
@@ -168,7 +166,7 @@ var DatePicker = function (_React$Component) {
             }
         }
     }, {
-        key: 'validateDateString',
+        key: "validateDateString",
         value: function validateDateString(string) {
             // Chrono returns a datetime stamp for valid dates, and for invalid dates, returns null
             return _chronoNode2.default.parseDate(string);
@@ -177,27 +175,33 @@ var DatePicker = function (_React$Component) {
         /**** handlers ****/
 
     }, {
-        key: 'toggleDatepicker',
+        key: "toggleDatepicker",
         value: function toggleDatepicker(type, e) {
-            if (e) e.stopPropagation();
+            if (e) {
+                e.stopPropagation();
+            }
 
             this.setState({
                 datepickerVisible: type
             }, this.toggleGlobalClickBinding.bind(this));
         }
     }, {
-        key: 'openDatepicker',
+        key: "openDatepicker",
         value: function openDatepicker(type, e) {
-            if (e) e.stopPropagation();
+            if (e) {
+                e.stopPropagation();
+            }
 
             this.setState({
                 datepickerVisible: type
             });
         }
     }, {
-        key: 'closeDatepicker',
+        key: "closeDatepicker",
         value: function closeDatepicker(type, e) {
-            if (e) e.stopPropagation();
+            if (e) {
+                e.stopPropagation();
+            }
 
             if (type === "startDate") {
                 this.handleStartDateSet();
@@ -208,7 +212,7 @@ var DatePicker = function (_React$Component) {
             this.toggleGlobalClickBinding();
         }
     }, {
-        key: 'handleDateSelection',
+        key: "handleDateSelection",
         value: function handleDateSelection(type, date, options) {
             var mutableDate = (0, _moment2.default)(date);
 
@@ -239,41 +243,41 @@ var DatePicker = function (_React$Component) {
 
             newState[type] = date;
             if (this.props.inputEditable) {
-                newState[type + 'InputValue'] = date.format(this.state.format);
+                newState[type + "InputValue"] = date.format(this.state.format);
             }
 
             this.setState(newState, this.handleOnChange.bind(this));
         }
     }, {
-        key: 'handleStartDateInputChange',
+        key: "handleStartDateInputChange",
         value: function handleStartDateInputChange(e) {
             this.setState({
                 startDateInputValue: e.target.value
             });
         }
     }, {
-        key: 'handleEndDateInputChange',
+        key: "handleEndDateInputChange",
         value: function handleEndDateInputChange(e) {
             this.setState({
                 endDateInputValue: e.target.value
             });
         }
     }, {
-        key: 'handleStartDateKeyPress',
+        key: "handleStartDateKeyPress",
         value: function handleStartDateKeyPress(e) {
             if (e.key === ENTER_KEY) {
                 this.handleStartDateSet();
             }
         }
     }, {
-        key: 'handleEndDateKeyPress',
+        key: "handleEndDateKeyPress",
         value: function handleEndDateKeyPress(e) {
             if (e.key === ENTER_KEY) {
                 this.handleEndDateSet();
             }
         }
     }, {
-        key: 'handleStartDateSet',
+        key: "handleStartDateSet",
         value: function handleStartDateSet() {
             var _this2 = this;
 
@@ -305,7 +309,7 @@ var DatePicker = function (_React$Component) {
             }
         }
     }, {
-        key: 'handleEndDateSet',
+        key: "handleEndDateSet",
         value: function handleEndDateSet() {
             var _this3 = this;
 
@@ -337,7 +341,7 @@ var DatePicker = function (_React$Component) {
             }
         }
     }, {
-        key: 'handleOnChange',
+        key: "handleOnChange",
         value: function handleOnChange() {
             if (this.props.isRange) {
                 this.props.onChange({
@@ -356,7 +360,7 @@ var DatePicker = function (_React$Component) {
         /**** render methods ****/
 
     }, {
-        key: 'renderDatepicker',
+        key: "renderDatepicker",
         value: function renderDatepicker(type) {
             if (this.state.datepickerVisible === type) {
                 return _react2.default.createElement(_dateView2.default, {
@@ -369,7 +373,7 @@ var DatePicker = function (_React$Component) {
             }
         }
     }, {
-        key: 'render',
+        key: "render",
         value: function render() {
             var endDateDatepicker = null,
                 divider = null,
@@ -386,14 +390,14 @@ var DatePicker = function (_React$Component) {
             if (this.props.isRange) {
                 var endDateValue = this.props.inputEditable ? this.state.endDateInputValue : this.state.endDate.format(this.state.format);
                 endDateDatepicker = _react2.default.createElement(
-                    'div',
-                    { className: 'datepicker-container' },
-                    _react2.default.createElement('i', { className: 'fa fa-calendar' }),
-                    _react2.default.createElement('input', { style: styles,
-                        className: 'datepicker-input',
+                    "div",
+                    { className: "datepicker-container" },
+                    _react2.default.createElement("i", { className: "fa fa-calendar" }),
+                    _react2.default.createElement("input", { style: styles,
+                        className: "datepicker-input",
                         readOnly: !this.props.inputEditable,
                         value: endDateValue,
-                        type: 'text',
+                        type: "text",
 
                         onChange: this.handleEndDateInputChange.bind(this),
                         onBlur: this.closeDatepicker.bind(this, "endDate"),
@@ -402,25 +406,25 @@ var DatePicker = function (_React$Component) {
                     this.renderDatepicker("endDate")
                 );
                 divider = _react2.default.createElement(
-                    'span',
-                    { className: 'datepicker-divider' },
-                    '-'
+                    "span",
+                    { className: "datepicker-divider" },
+                    "-"
                 );
             }
             var startDateValue = this.props.inputEditable ? this.state.startDateInputValue : this.state.startDate.format(this.state.format);
 
             var content = _react2.default.createElement(
-                'div',
-                { onClick: stopBubble, className: 'datepicker-wrapper' },
+                "div",
+                { onClick: stopBubble, className: "datepicker-wrapper" },
                 _react2.default.createElement(
-                    'div',
-                    { className: 'datepicker-container' },
-                    _react2.default.createElement('i', { className: 'fa fa-calendar' }),
-                    _react2.default.createElement('input', { style: styles,
-                        className: 'datepicker-input',
+                    "div",
+                    { className: "datepicker-container" },
+                    _react2.default.createElement("i", { className: "fa fa-calendar" }),
+                    _react2.default.createElement("input", { style: styles,
+                        className: "datepicker-input",
                         readOnly: !this.props.inputEditable,
                         value: startDateValue,
-                        type: 'text',
+                        type: "text",
                         onBlur: this.closeDatepicker.bind(this, "startDate"),
                         onFocus: this.openDatepicker.bind(this, "startDate"),
                         onChange: this.handleStartDateInputChange.bind(this),

--- a/build/js/datepicker.js
+++ b/build/js/datepicker.js
@@ -282,11 +282,15 @@ var DatePicker = function (_React$Component) {
             var minDate = this.getMinDateForType("startDate");
             var maxDate = this.getMaxDateForType("startDate");
 
+            if (!this.props.enableTime) {
+                // round to make sure it's simply the same date;
+                startDate.hour(0).minute(0).second(0).millisecond(0);
+            }
             // If it's a valid date string and the date is within range, set the start date to be the input value
             if (dateString && startDate.isSameOrAfter(minDate) && startDate.isSameOrBefore(maxDate)) {
                 this.setState({
                     startDate: startDate,
-                    startDateInputValue: (0, _moment2.default)(dateString).format(this.state.format)
+                    startDateInputValue: startDate.format(this.state.format)
                 }, function () {
                     _this2.handleOnChange();
                     if (_this2.dateView.current) {
@@ -299,8 +303,6 @@ var DatePicker = function (_React$Component) {
                     startDateInputValue: this.state.startDate.format(this.state.format)
                 });
             }
-
-            this.forceUpdate();
         }
     }, {
         key: 'handleEndDateSet',
@@ -312,11 +314,15 @@ var DatePicker = function (_React$Component) {
             var minDate = this.getMinDateForType("endDate");
             var maxDate = this.getMaxDateForType("endDate");
 
+            if (!this.props.enableTime) {
+                // round to make sure it's simply the same date;
+                endDate.hour(0).minute(0).second(0).millisecond(0);
+            }
             // If it's a valid date string and the date is within range, set the start date to be the input value
             if (dateString && endDate.isSameOrAfter(minDate) && endDate.isSameOrBefore(maxDate)) {
                 this.setState({
                     endDate: endDate,
-                    endDateInputValue: (0, _moment2.default)(dateString).format(this.state.format)
+                    endDateInputValue: endDate.format(this.state.format)
                 }, function () {
                     _this3.handleOnChange();
                     if (_this3.dateView.current) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-datetimepicker",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "A simple datepicker for react.",
   "main": "build/js/datepicker.js",
   "scripts": {


### PR DESCRIPTION
## Summary
This fixes the issue which was identified in our Discovery app where when a date is selected in intelligence, the following date is what actually gets selected. The issue had to do with the time being set when `enableTime` was set to false (so time should have been ignored). Previously, we set the time to 0, so I did the same for this case to ensure the date is respected.

**Note:** This PR also includes some lint fixes. To see just the solution to the bug, check out the first commit only.

![dateissue](https://user-images.githubusercontent.com/3075343/50531090-03d24580-0ad3-11e9-97c3-0e7ffe876844.gif)

